### PR TITLE
Add project: JupyterLab Marketplace

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1493,3 +1493,9 @@ projects:
     category: kernels
     pypi_id: nbstata
     docs_url: https://hugetim.github.io/nbstata/
+  - name: JupyterLab Marketplace
+    github_id: orbrx/jupyter-marketplace
+    category: notebook-tools
+    homepage: https://marketplace.orbrx.io/
+    license: Apache-2.0
+    description: A community-run marketplace for JupyterLab extensions with real-world signals from PyPI and GitHub


### PR DESCRIPTION
Adding JupyterLab Marketplace to the best-of-jupyter list.

**Project:** JupyterLab Marketplace
**GitHub:** https://github.com/orbrx/jupyter-marketplace
**Homepage:** https://marketplace.orbrx.io/
**Category:** notebook-tools

A community-run marketplace for JupyterLab extensions that surfaces real-world signals from PyPI (via BigQuery) and GitHub—stars, recent updates, and download trends—to make extension discovery easier.

Features:
- 🔎 Search across extensions
- 🧭 Multiple sort options
- 🧱 Cards show stars, downloads, and update frequency
- ♾️ Infinite scroll
- 🪄 Keyboard-friendly UI